### PR TITLE
Updated ConfigurableProperties to set used ISimilarityChecker

### DIFF
--- a/src/main/java/uk/ac/ebi/pride/spectracluster/hadoop/util/ConfigurableProperties.java
+++ b/src/main/java/uk/ac/ebi/pride/spectracluster/hadoop/util/ConfigurableProperties.java
@@ -1,6 +1,7 @@
 package uk.ac.ebi.pride.spectracluster.hadoop.util;
 
 import org.apache.hadoop.conf.Configuration;
+import uk.ac.ebi.pride.spectracluster.similarity.*;
 import uk.ac.ebi.pride.spectracluster.util.Defaults;
 import uk.ac.ebi.pride.spectracluster.util.NumberUtilities;
 
@@ -26,12 +27,13 @@ import java.io.IOException;
 public class ConfigurableProperties {
 
     public static final String NUMBER_COMPARED_PEAKS_PROPERTY = "pride.cluster.number.compared.peaks";
-    public static final String SIMILARITY_MZ_RANGE_PROPERTY = "pride.cluster.similarity.mz.range";
+    public static final String FRAGMENT_ION_TOLERANCE_PROPERTY = "pride.cluster.similarity.fragment.tolerance";
     public static final String RETAIN_THRESHOLD_PROPERTY = "pride.cluster.retain.threshold";
     public static final String SIMILARITY_THRESHOLD_PROPERTY = "pride.cluster.similarity.threshold";
     public static final String SPECTRUM_MERGE_WINDOW_PROPERTY = "pride.cluster.spectrum.merge.window";
     public static final String MAJOR_PEAK_WINDOW_PROPERTY = "pride.cluster.major.peak.window";
 
+    public static final String SIMILARITY_CHECKER_PROPERTY = "pride.cluster.similarity.checker";
 
     /**
      * this method and the one below
@@ -40,13 +42,30 @@ public class ConfigurableProperties {
      */
     public static void configureAnalysisParameters(Configuration configuration) {
         Defaults.setNumberComparedPeaks(configuration.getInt(NUMBER_COMPARED_PEAKS_PROPERTY, Defaults.DEFAULT_NUMBER_COMPARED_PEAKS));
-        Defaults.setSimilarityMZRange(configuration.getFloat(SIMILARITY_MZ_RANGE_PROPERTY, new Float(Defaults.DEFAULT_MZ_RANGE)));
+        Defaults.setFragmentIonTolerance(configuration.getFloat(FRAGMENT_ION_TOLERANCE_PROPERTY, new Float(Defaults.DEFAULT_FRAGMENT_ION_TOLERANCE)));
         Defaults.setRetainThreshold(configuration.getFloat(RETAIN_THRESHOLD_PROPERTY, new Float(Defaults.DEFAULT_RETAIN_THRESHOLD)));
         Defaults.setSimilarityThreshold(configuration.getFloat(SIMILARITY_THRESHOLD_PROPERTY, new Float(Defaults.DEFAULT_SIMILARITY_THRESHOLD)));
+
+        // similarity checker - this must be created AFTER the fragmentIonTolerance property is being read
+        Defaults.setDefaultSimilarityChecker(getSimilarityCheckerFromConfiguration(configuration));
 
         // hadoop related properties
         ClusterHadoopDefaults.setMajorPeakMZWindowSize(configuration.getFloat(MAJOR_PEAK_WINDOW_PROPERTY, new Float(ClusterHadoopDefaults.DEFAULT_MAJOR_PEAK_MZ_WINDOW)));
         ClusterHadoopDefaults.setSpectrumMergeMZWindowSize(configuration.getFloat(SPECTRUM_MERGE_WINDOW_PROPERTY, new Float(ClusterHadoopDefaults.DEFAULT_SPECTRUM_MERGE_WINDOW)));
+    }
+
+    private static ISimilarityChecker getSimilarityCheckerFromConfiguration(Configuration configuration) {
+        Class similarityCheckerClass = configuration.getClass(SIMILARITY_CHECKER_PROPERTY, Defaults.getDefaultSimilarityChecker().getClass(), ISimilarityChecker.class);
+        ISimilarityChecker similarityChecker;
+        try {
+            similarityChecker = (ISimilarityChecker) similarityCheckerClass.newInstance();
+        }
+        catch (Exception e) {
+            // throw an IllegalStateException for now
+            throw new IllegalStateException(e);
+        }
+
+        return similarityChecker;
     }
 
 
@@ -58,11 +77,12 @@ public class ConfigurableProperties {
     public static void appendAnalysisParameters(Appendable out) {
         try {
             out.append(NUMBER_COMPARED_PEAKS_PROPERTY).append("=").append(String.valueOf(Defaults.getNumberComparedPeaks())).append("\n");
-            out.append(SIMILARITY_MZ_RANGE_PROPERTY).append("=").append(NumberUtilities.formatDouble(Defaults.getSimilarityMZRange(), 3)).append("\n");
+            out.append(FRAGMENT_ION_TOLERANCE_PROPERTY).append("=").append(NumberUtilities.formatDouble(Defaults.getFragmentIonTolerance(), 3)).append("\n");
             out.append(SIMILARITY_THRESHOLD_PROPERTY).append("=").append(NumberUtilities.formatDouble(Defaults.getSimilarityThreshold(), 3)).append("\n");
             out.append(RETAIN_THRESHOLD_PROPERTY).append("=").append(NumberUtilities.formatDouble(Defaults.getRetainThreshold(), 3)).append("\n");
             out.append(MAJOR_PEAK_WINDOW_PROPERTY).append("=").append(NumberUtilities.formatDouble(ClusterHadoopDefaults.getMajorPeakMZWindowSize(), 3)).append("\n");
             out.append(SPECTRUM_MERGE_WINDOW_PROPERTY).append("=").append(NumberUtilities.formatDouble(ClusterHadoopDefaults.getSpectrumMergeMZWindowSize(), 3)).append("\n");
+            // TODO: discuss how to add the used ISimilarityChecker here
         } catch (IOException e) {
             throw new RuntimeException(e);
 


### PR DESCRIPTION
Updated ConfigurableProperties to also update the used ISimilarityChecker.

This change also incorporates the required changes required by spectra-cluster/spectra-cluster#6. The local variables were renamed for consistency reasons.

A possible configuration would look like:
```XML
    <property>
        <name>pride.cluster.similarity.checker</name>
        <value>uk.ac.ebi.pride.spectracluster.similarity.FisherExactTest</value>
    </property>

    <property>
        <name>pride.cluster.similarity.threshold</name>
        <value>55</value>
    </property>

    <property>
        <name>pride.cluster.retain.threshold</name>
        <value>50</value>
    </property>
```

@ruiwanguk Any feedback highly welcome!